### PR TITLE
Fix sharing model on simple sales order item not used as orderitem used instead

### DIFF
--- a/force-app/main/default/objects/Simple_Sales_Order_Item__c/Simple_Sales_Order_Item__c.object-meta.xml
+++ b/force-app/main/default/objects/Simple_Sales_Order_Item__c/Simple_Sales_Order_Item__c.object-meta.xml
@@ -160,6 +160,6 @@
     </nameField>
     <pluralLabel>Simple Sales Order Items</pluralLabel>
     <searchLayouts/>
-    <sharingModel>ControlledByParent</sharingModel>
+    <sharingModel>ReadWrite</sharingModel>
     <visibility>Public</visibility>
 </CustomObject>


### PR DESCRIPTION
Fix sharing model on simple sales order item not used as orderitem used instead